### PR TITLE
Add case_sensitive to `token` uniqueness validation

### DIFF
--- a/app/models/caffeinate/campaign_subscription.rb
+++ b/app/models/caffeinate/campaign_subscription.rb
@@ -52,7 +52,7 @@ module Caffeinate
     scope :ended, -> { where.not(ended_at: nil) }
 
     before_validation :set_token!, on: [:create]
-    validates :token, uniqueness: true, on: [:create]
+    validates :token, uniqueness: { case_sensitive: true }, on: [:create]
 
     before_validation :call_dripper_before_subscribe_blocks!, on: :create
 


### PR DESCRIPTION
Rails 6.1 will no longer enforce case sensitivity by default, adding `case_sensitive: true` makes sure the behavior remains the same after upgrading.